### PR TITLE
add LOCALE US.UTF-8 to support powerline ASCII

### DIFF
--- a/shell/zshrc
+++ b/shell/zshrc
@@ -29,3 +29,7 @@ export PATH="/usr/local/sbin:$PATH"
 export PATH="/usr/local/opt/openjdk/bin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 export PATH="$HOME/.rbenv/bin:$PATH"
+
+# LOCALE to display correctly ASCII on powerline
+export LC_ALL=en_US.UTF-8
+export LANG=en_US.UTF-8


### PR DESCRIPTION
Add LOCALE US.UTF-8 

# Problem

If the terminal `LOCALE` is running on different values powerline is not displaying correctly characters

![Screenshot 2023-08-09 at 13 06 35](https://github.com/cesargomez89/inspiration-dotfiles/assets/1800826/ee9bde05-6871-4d1e-b645-7ffc9c9bdf80)

# Fix

After add US.UTF-8 problem is gone

![image](https://github.com/cesargomez89/inspiration-dotfiles/assets/1800826/2e68eaf5-8bc8-4fc8-88c6-fb10e487c222)
